### PR TITLE
Fix trigger_exit() not being used

### DIFF
--- a/util/state_machine/state.gd
+++ b/util/state_machine/state.gd
@@ -74,7 +74,7 @@ func trigger_exit():
 ## Ditch this state and all its descendents,
 ## making this branch of the state tree inactive.
 func ditch_state():
-	_on_exit()
+	trigger_exit()
 
 	# Ditch live descendents
 	if live_substate == null: return


### PR DESCRIPTION
The `trigger_exit()` function was meant to be used in place of calling `_on_exit()` directly. However, it was only used in `reset_state()` and not `ditch_state()`. This resolves that.