### PR TITLE
Player movement: Slipping implementation attempt

### DIFF
--- a/actors/player/mario/mario.tscn
+++ b/actors/player/mario/mario.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=337 format=3 uid="uid://dgqp3sqvmcvpu"]
+[gd_scene load_steps=338 format=3 uid="uid://dgqp3sqvmcvpu"]
 
 [ext_resource type="Script" path="res://actors/player/player.gd" id="1_3d0l6"]
 [ext_resource type="Texture2D" uid="uid://bbgppbst4akvn" path="res://actors/player/mario/anime/backflip.png" id="2_i2o54"]
@@ -83,6 +83,7 @@
 [ext_resource type="Script" path="res://actors/player/states/airborne/twirl.gd" id="57_dqusk"]
 [ext_resource type="AudioStream" uid="uid://bwsqbo0shsv1n" path="res://actors/player/mario/motion_nsmbw/triplejump.wav" id="59_wk6r7"]
 [ext_resource type="AudioStream" uid="uid://cwkfh51wv1ios" path="res://actors/player/mario/motion_nsmbw/triplejumpflip.wav" id="60_07vye"]
+[ext_resource type="Script" path="res://actors/player/states/grounded/slip.gd" id="60_456op"]
 [ext_resource type="AudioStream" uid="uid://dx127oekmmsnc" path="res://actors/player/mario/voice/yo_jump.wav" id="64_rch8v"]
 [ext_resource type="Script" path="res://actors/player/states/airborne/spin_wallbonk.gd" id="65_echk5"]
 [ext_resource type="AudioStream" uid="uid://bvngsvbfij5rl" path="res://actors/player/mario/voice/uhn_jump.wav" id="65_f1kp6"]
@@ -1971,6 +1972,11 @@ sfx_layers = Array[ExtResource("49_apkmk")]([SubResource("Resource_t5lrn")])
 
 [node name="DiveSlide" type="Node" parent="StateManager/Grounded"]
 script = ExtResource("45_alo0d")
+hitbox_type = "Dive"
+animation = &"dive_slide"
+
+[node name="Slip" type="Node" parent="StateManager/Grounded"]
+script = ExtResource("60_456op")
 hitbox_type = "Dive"
 animation = &"dive_slide"
 

--- a/actors/player/states/airborne/backflip.gd
+++ b/actors/player/states/airborne/backflip.gd
@@ -31,6 +31,9 @@ func _subsequent_ticks():
 
 
 func _trans_rules():
+	if movement.is_steep_slope():
+		return &"Slip"
+	
 	if actor.push_rays.is_colliding() and input.buffered_input(&"jump"):
 		return [&"Walljump", -movement.facing_direction]
 

--- a/actors/player/states/airborne/fall.gd
+++ b/actors/player/states/airborne/fall.gd
@@ -34,6 +34,9 @@ func _trans_rules():
 	if movement.can_init_wallslide():
 		return &"Wallslide"
 
+	if movement.is_steep_slope():
+		return &"Slip"
+
 	if movement.finished_freefall_timer():
 		return &"Freefall"
 

--- a/actors/player/states/butt_slide.gd
+++ b/actors/player/states/butt_slide.gd
@@ -214,7 +214,7 @@ func _trans_rules():
 	if not movement.is_slide_slope() and is_equal_approx(actor.vel.x, 0):
 		return [&"Crouch", [true, false]]
 
-	if actor.is_on_floor():
+	if actor.is_on_floor() and !movement.is_steep_slope():
 		if not Input.is_action_pressed(&"down"):
 			if old_direction.y == 0 and input_dir != 0 or Input.is_action_just_pressed(&"up"):
 				return &"Idle"

--- a/actors/player/states/grounded.gd
+++ b/actors/player/states/grounded.gd
@@ -22,9 +22,6 @@ func _trans_rules():
 	if not actor.is_on_floor():
 		return &"Fall"
 
-	if movement.is_steep_slope():
-			return &"Slip"
-
 	return &""
 
 

--- a/actors/player/states/grounded.gd
+++ b/actors/player/states/grounded.gd
@@ -22,6 +22,9 @@ func _trans_rules():
 	if not actor.is_on_floor():
 		return &"Fall"
 
+	if movement.is_steep_slope():
+			return &"Slip"
+
 	return &""
 
 

--- a/actors/player/states/grounded/dive_slide.gd
+++ b/actors/player/states/grounded/dive_slide.gd
@@ -49,4 +49,7 @@ func _trans_rules():
 
 		return &"Idle"
 
+	if movement.is_steep_slope():
+		return &"Slip"
+
 	return &""

--- a/actors/player/states/grounded/idle.gd
+++ b/actors/player/states/grounded/idle.gd
@@ -40,4 +40,7 @@ func _trans_rules():
 	if input.buffered_input(&"jump"):
 		return &"DummyJump"
 
+	if movement.is_steep_slope():
+		return &"Slip"
+
 	return &""

--- a/actors/player/states/grounded/slip.gd
+++ b/actors/player/states/grounded/slip.gd
@@ -1,0 +1,101 @@
+class_name Slip
+extends PlayerState
+## An attempt to implement slipping Slipping from a steep slope.
+## Mostly made up of remixed sliding and diving code spliced together.
+
+@export var slip_accel: float = 0.5
+@export var max_slip_speed: float = 15
+@export var slip_friction: float = 0.05
+
+var slip_speed: float = 0.0
+
+func _on_enter(_handover):
+	slip_speed = 0.0
+	actor.floor_stop_on_slope = false
+	actor.doll.rotation = movement.body_rotation
+
+
+func _physics_tick():
+	var normal_angle: float = actor.get_floor_normal().angle()
+	var angle: float = normal_angle + TAU / 2 * Math.sign_positive(movement.facing_direction)
+
+	actor.doll.rotation = lerp_angle(actor.doll.rotation, angle, 0.5)
+
+	_modify_speed()
+
+
+func _on_exit():
+	actor.floor_stop_on_slope = true
+	actor.doll.rotation = 0
+
+
+func _modify_speed():
+	if movement.is_steep_slope():
+		_accelerate(slip_accel, max_slip_speed)
+	elif !movement.is_steep_slope():
+		movement.decelerate(slip_friction)
+
+
+func _accelerate(amount: Variant, speed_cap: float):
+	var floor_normal: Vector2 = actor.get_floor_normal()
+	var slip_direction: Vector2
+	slip_direction = _get_slip_dir(floor_normal)
+	
+	if slip_speed + amount < speed_cap:
+		slip_speed += amount
+	elif slip_speed > speed_cap:
+		slip_speed = speed_cap
+
+	actor.vel = slip_direction * slip_speed
+	actor.vel.y += 0.1
+
+
+## Get the slide direction downwards along the slope.
+func _get_slip_dir(floor_normal: Vector2) -> Vector2:
+	var direction: Vector2
+
+	if floor_normal == Vector2.UP:
+		# On flat ground, just go right.
+		direction = Vector2.RIGHT
+	else:
+		direction = floor_normal.orthogonal()
+
+		if direction.dot(Vector2.DOWN) < 0:
+			direction = -direction
+
+	return direction
+
+
+func _trans_rules():
+	if !movement.is_steep_slope():
+		if not actor.crouchlock.enabled:
+			if movement.can_spin() and input.buffered_input(&"spin"):
+				return &"Spin"
+
+			if input.buffered_input(&"dive"):
+				return [&"Dive", true]
+
+			if (
+				(InputManager.get_x_dir() == movement.facing_direction 
+				or InputManager.get_x_dir() == 0)
+				and (input.buffered_input(&"jump") 
+				or Input.is_action_pressed(&"jump"))
+			):
+				return &"Rollout"
+
+		if Input.is_action_pressed(&"down"):
+			if movement.is_slide_slope():
+				return &"ButtSlide"
+
+			return [&"Crouch", [true, false]]
+
+		if is_zero_approx(actor.vel.x) or InputManager.get_x_dir() == -movement.facing_direction:
+			if actor.crouchlock.enabled:
+				return [&"Crouch", [true, false]]
+
+			return &"Idle"
+
+		if actor.vel.x == 0:
+			return &"Idle"
+
+	return &""

--- a/actors/player/states/grounded/walk.gd
+++ b/actors/player/states/grounded/walk.gd
@@ -87,4 +87,11 @@ func _trans_rules():
 
 		return &"DryPush"
 
+	## the following causes a weird interaction where mario constantly slips and gets back up
+	## of a second but gets back up immediately only to repeat it again. To be fair though
+	## this interaction is actually present in some mario games and can be prevented by just
+	## designing levels with this in mind
+	if movement.is_steep_slope():
+		return &"Slip"
+
 	return &""

--- a/actors/player/states/grounded/walk.gd
+++ b/actors/player/states/grounded/walk.gd
@@ -87,10 +87,7 @@ func _trans_rules():
 
 		return &"DryPush"
 
-	## the following causes a weird interaction where mario constantly slips and gets back up
-	## of a second but gets back up immediately only to repeat it again. To be fair though
-	## this interaction is actually present in some mario games and can be prevented by just
-	## designing levels with this in mind
+	## the following causes a weird interaction where mario constantly slips and gets back up.
 	if movement.is_steep_slope():
 		return &"Slip"
 

--- a/areas/funny_slope_test.tscn
+++ b/areas/funny_slope_test.tscn
@@ -44,7 +44,7 @@ shader_parameter/mix_amount = 1.4
 [node name="FunnySlopeTest" type="Node2D"]
 
 [node name="Mario" parent="." instance=ExtResource("1_pj472")]
-position = Vector2(1816, -80)
+position = Vector2(1672, -744)
 floor_snap_length = 0.0
 
 [node name="Camera2D" type="Camera2D" parent="Mario"]
@@ -57,7 +57,7 @@ drag_top_margin = 1.0
 [node name="Polygon2D" type="Polygon2D" parent="."]
 texture_repeat = 2
 texture = ExtResource("3_j68gy")
-polygon = PackedVector2Array(384, 0, 640, -64, 896, 0, 1152, 0, 1280, -64, 1408, 0, 1600, 0, 1664, -64, 1728, 0, 1920, 0, 2880, -832, 2304, 0, 2496, 0, 2496, 256, -31, 1534, 34, 931, -120, 256, -568, 0)
+polygon = PackedVector2Array(384, 0, 640, -64, 896, 384, 1152, 384, 1280, -64, 1408, 0, 1600, 0, 1664, -64, 1728, 0, 1920, 0, 2880, -832, 2304, 0, 2496, 0, 2496, 256, -31, 1534, 34, 931, -120, 256, -568, 0)
 uv = PackedVector2Array(200, 0, 200, -8, 232, -8, 232, 0, 280, 0, 280, -16, 312, -16, 312, 0, 384, 0, 640, -64, 896, 0, 1152, 0, 1280, -64, 1408, 0, 1600, 0, 1664, -64, 1728, 0, 1920, 0, 1984, -128, 2048, 0, 2240, 0, 2272, -128, 2304, 0, 2496, 0, 2496, 256, -31, 1534, 34, 931, -120, 256, -568, 0, -256, 0, -261.989, -103.448, -192, -192, -192, -128, -128, -128, -128, -64, -64, -64, -64, 0, -39.3632, 0)
 script = ExtResource("4_fbq2w")
 


### PR DESCRIPTION
Saw slipping was unimplemented and attempted adding it in. Uses code from sliding and diving actions spliced together.

Added Slip.gd file and linked the action in by attaching transitions from fall, idle, dive_slide and walk scripts. Couldn't remember exactly how slipping from steep angles worked in game so implemented it based off memory, behaviour will likely need to be tweaked or rewritten. Made it so that no action can be preformed until `movement.is_steep_slope() == False` to prevent players from doing things like infinitely long jumping up a steep slope. Slipping continues for a bit after `movement.is_steep_slope() == False` but preforming an action allows you to break out of it early similar to Mario 64 DS. Hopefully this code is useful.

This'll probably be my last contribution (for a while at least). It was a nice challenge having a shot at fixing an issue or trying to implement something. If someone had already been assigned this task or this wasn't how you intended slipping to be implemented feel free to ignore this merge request.