### PR TITLE
Add various forms of friction to swimming to prevent unlimited speed gain

### DIFF
--- a/actors/player/mario/mario.tscn
+++ b/actors/player/mario/mario.tscn
@@ -2043,6 +2043,7 @@ anim_offset = Vector2i(0, 5)
 [node name="Swim" type="Node" parent="StateManager/Submerged"]
 script = ExtResource("41_x14c0")
 swimming_speed = 4.0
+swimming_accel_time = 4
 animation = &"swim"
 anim_offset = Vector2i(0, 5)
 

--- a/actors/player/shared/states/submerged/swim.gd
+++ b/actors/player/shared/states/submerged/swim.gd
@@ -7,7 +7,9 @@ extends PlayerState
 
 
 func _physics_tick():
-	movement.accelerate(InputManager.get_vec(), swimming_speed)
+	var accel_step: float = swimming_speed / float(swimming_accel_time)
+	movement.accelerate(InputManager.get_vec() * accel_step, swimming_speed, 0.03125)
+	movement.radial_friction(0.0625, swimming_speed)
 
 
 func _trans_rules():


### PR DESCRIPTION
Three forms of friction are applied:
- Soft speed cap. Prevent the player from increasing their overall speed while over the speed cap.
- Perpendicular friction. When the player is moving in a direction different to the current direction of motion, apply friction on the perpendicular axis so they don't continue to drift in that direction.
- Radial friction. When the player is above the speed cap, apply friction to reduce them to the cap.