### PR TITLE
camera motions now framerate independent

### DIFF
--- a/entities/player/shared/player_camera.gd
+++ b/entities/player/shared/player_camera.gd
@@ -42,7 +42,6 @@ func _physics_process(delta: float) -> void:
 
 	zoom = Vector2(zoom_factor, zoom_factor)
 
-
 	velocity_offset = velocity_offset.lerp(
 		player.velocity * delta * velocity_pan_factor,
 		Math.interp_weight_idp(pan_follow_speed, delta)
@@ -60,8 +59,7 @@ func _input(event: InputEvent) -> void:
 			target_zoom -= 25
 		else:
 			target_zoom -= 50
-		
-		
+
 	if event.is_action_pressed(&"camera_zoom_out"):
 		if target_zoom != zoom_max:
 			zoom_out_sfx.play_sfx_at(self)

--- a/entities/player/shared/player_camera.gd
+++ b/entities/player/shared/player_camera.gd
@@ -35,7 +35,7 @@ var velocity_offset: Vector2 = Vector2.ZERO
 func _physics_process(delta: float) -> void:
 	zoom_percentage = lerp(zoom_percentage, 
 		target_zoom,
-		Math.lerp_weight_idp(zoom_follow_speed, delta)
+		Math.interp_weight_idp(zoom_follow_speed, delta)
 	)
 
 	var zoom_factor: float = 1 / (zoom_percentage / 100)
@@ -45,7 +45,7 @@ func _physics_process(delta: float) -> void:
 
 	velocity_offset = velocity_offset.lerp(
 		player.velocity * delta * velocity_pan_factor,
-		Math.lerp_weight_idp(pan_follow_speed, delta)
+		Math.interp_weight_idp(pan_follow_speed, delta)
 	)
 
 	position = velocity_offset

--- a/entities/player/shared/player_camera.gd
+++ b/entities/player/shared/player_camera.gd
@@ -7,13 +7,13 @@ extends Camera2D
 @export var zoom_max: float = 200
 @export var zoom_min: float = 50
 
-@export var zoom_weight_factor: float = 5.0
+@export var zoom_follow_speed: float = 5.0
 
 @export_category(&"Velocity Panning Variables")
 ## How much the velocity that's added to the position is multiplied by.
 @export var velocity_pan_factor: float = 8.0
 
-@export var pan_weight_factor: float = 2.0
+@export var pan_follow_speed: float = 2.0
 
 @export_category(&"")
 ## Current camera properties
@@ -33,18 +33,22 @@ var velocity_offset: Vector2 = Vector2.ZERO
 
 
 func _physics_process(delta: float) -> void:
-	zoom_percentage = lerp(zoom_percentage, target_zoom, zoom_weight_factor * delta)
+	zoom_percentage = lerp(zoom_percentage, 
+		target_zoom,
+		Math.lerp_weight_idp(zoom_follow_speed, delta)
+	)
 
 	var zoom_factor: float = 1 / (zoom_percentage / 100)
 
 	zoom = Vector2(zoom_factor, zoom_factor)
-	
+
+
 	velocity_offset = velocity_offset.lerp(
-		player.vel * velocity_pan_factor,
-		pan_weight_factor * delta
+		player.velocity * delta * velocity_pan_factor,
+		Math.lerp_weight_idp(pan_follow_speed, delta)
 	)
-	
-	#position = velocity_offset
+
+	position = velocity_offset
 
 
 func _input(event: InputEvent) -> void:
@@ -56,6 +60,8 @@ func _input(event: InputEvent) -> void:
 			target_zoom -= 25
 		else:
 			target_zoom -= 50
+		
+		
 	if event.is_action_pressed(&"camera_zoom_out"):
 		if target_zoom != zoom_max:
 			zoom_out_sfx.play_sfx_at(self)

--- a/entities/player/shared/states/dry/grounded/walk.gd
+++ b/entities/player/shared/states/dry/grounded/walk.gd
@@ -39,7 +39,7 @@ func _physics_tick():
 func _set_appropriate_anim():
 	var current_progress = actor.doll.get_frame_progress()
 
-	if Math.roundp(abs(actor.vel.x), 3) > movement.max_speed:
+	if snappedf(abs(actor.vel.x), 3) > movement.max_speed:
 		actor.doll.play(animation_run)
 		actor.doll.set_frame_and_progress(current_frame, current_progress)
 

--- a/entities/player/shared/states/submerged/swim_hard.gd
+++ b/entities/player/shared/states/submerged/swim_hard.gd
@@ -2,7 +2,7 @@ class_name SwimHard
 extends PlayerState
 ## Pressing jump while underwater to get a short boost.
 
-## Gets added on top of [code]Movement[/code]'s [code]swim_speed[/code].
+## Gets added on top of [member PMovement.swim_speed].
 @export var extra_boost_speed: float
 
 var boost_speed: float

--- a/entities/player/shared/states/submerged/swim_spin.gd
+++ b/entities/player/shared/states/submerged/swim_spin.gd
@@ -2,7 +2,7 @@ class_name SwimSpin
 extends PlayerState
 ## Spinning underwater.
 
-## Gets added on top of [code]Movement[/code]'s [code]swim_speed[/code].
+## Gets added on top of [member PMovement.swim_speed].
 @export var extra_boost_speed: float
 
 

--- a/project.godot
+++ b/project.godot
@@ -230,6 +230,11 @@ debug_toggle={
 2d_physics/layer_9="Preview (Editor)"
 2d_physics/layer_10="Level Preview Field (Editor)"
 
+[physics]
+
+common/physics_jitter_fix=0.0
+common/physics_interpolation=true
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/props/terrain/terrain_editor.gd
+++ b/props/terrain/terrain_editor.gd
@@ -92,7 +92,7 @@ func _line_edit_mode():
 
 
 ## Force rewrites the polygon when a point is removed.[br][br]
-## [code]to_be_removed[/code] is a reference to the point that's being removed.
+## [param to_be_removed] is a reference to the point that's being removed.
 func _remove_point_on_poly(to_be_removed: Node2D):
 	if not points.size() >= 3:
 		return

--- a/ui/ui.gd
+++ b/ui/ui.gd
@@ -36,9 +36,9 @@ var current_notifs: Array = []
 
 ## This variable is set in [code]world_machine.tscn[/code].
 var world_machine: WorldMachine
-## See [code]_set_player()[/code].
+## See [method _set_player].
 var player: CharacterBody2D
-## See [code]_set_camera()[/code].
+## See [method _set_camera].
 var camera: PlayerCamera
 
 

--- a/util/math_util.gd
+++ b/util/math_util.gd
@@ -5,9 +5,11 @@ class_name Math
 static func sign_positive(input: Variant) -> Variant:
 	return max(sign(input), 0)
 
+
 ## Makes a weight supplied to a [method @GlobalScope.lerp] or [method @GlobalScope.cubic_interpolate] function framerate independent (for procedural animations with either method).
 static func interp_weight_idp(weight : float, delta : float) -> float:
-	return 1-exp(-weight * delta)
+	return 1 - exp(-weight * delta)
+
 
 ### Returns the closest point on a line in relation to the reference point.
 #static func get_closest_point_line(

--- a/util/math_util.gd
+++ b/util/math_util.gd
@@ -1,16 +1,13 @@
 class_name Math
-## Provides useful math functions that you can call using [code]Math.function_name[/code].
-
-
-## Round a value to a specific decimal place.
-static func roundp(value: float, decimal: int) -> float:
-	return round(value * pow(10, decimal)) / pow(10, decimal)
-
+## Provides useful math functions that you can call using [code]Math.function_name()[/code].
 
 ## If input is positive, returns 1. If input is negative or zero, returns 0.
 static func sign_positive(input: Variant) -> Variant:
 	return max(sign(input), 0)
 
+## Makes a weight supplied to a [code]lerp()[/code] function framerate independent (for procedural animations with [code]lerp()[/code]).
+static func lerp_weight_idp(weight : float, delta : float) -> float:
+	return 1-exp(-weight * delta)
 
 ### Returns the closest point on a line in relation to the reference point.
 #static func get_closest_point_line(

--- a/util/math_util.gd
+++ b/util/math_util.gd
@@ -5,8 +5,8 @@ class_name Math
 static func sign_positive(input: Variant) -> Variant:
 	return max(sign(input), 0)
 
-## Makes a weight supplied to a [code]lerp()[/code] function framerate independent (for procedural animations with [code]lerp()[/code]).
-static func lerp_weight_idp(weight : float, delta : float) -> float:
+## Makes a weight supplied to a [method @GlobalScope.lerp] or [method @GlobalScope.cubic_interpolate] function framerate independent (for procedural animations with either method).
+static func interp_weight_idp(weight : float, delta : float) -> float:
 	return 1-exp(-weight * delta)
 
 ### Returns the closest point on a line in relation to the reference point.

--- a/util/particle_effect.gd
+++ b/util/particle_effect.gd
@@ -13,7 +13,7 @@ var timer: int = loop_delay
 
 
 ## Emit the particle at a specific node.[br]
-## [code]offset_overwrite[/code] is useful if you want to use logic defined offsets instead.
+## [param offset_overwrite] is useful if you want to use logic defined offsets instead.
 func emit_at(node: Node, offset_overwrite := Vector2.ZERO):
 	if timer > 0:
 		timer = max(timer - 1, 0)


### PR DESCRIPTION
- camera lookahead and zoom now do not rely on the framerate for their speed of modification
- renamed a few variables in the camera script to better represent their purpose
- removed roundp() and replaced any instances of it with snapped() instead
- added lerp_weight_idp() which is used to make weight supplied to lerps that makes them framerate independent
- enabled physics interpolation for testing purposes