### PR TITLE
Add debug collision visibility toggle

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -226,6 +226,11 @@ toggle_hud={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":72,"key_label":0,"unicode":104,"location":0,"echo":false,"script":null)
 ]
 }
+debug_toggle_collision_shapes={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/ui/ui.gd
+++ b/ui/ui.gd
@@ -48,6 +48,7 @@ var hud_enabled: bool = true
 
 func _ready():
 	_toggle_debug()
+	_toggle_debug_hitboxes()
 	_set_player()
 	_set_camera()
 
@@ -83,6 +84,8 @@ func _input(event: InputEvent):
 func _setting_changed(key: String, _value: Variant) -> void:
 	if key == "debug_toggle":
 		_toggle_debug()
+	if key == "debug_toggle_collision_shapes":
+		_toggle_debug_hitboxes()
 
 
 func _pause_logic():
@@ -158,6 +161,13 @@ func _toggle_debug():
 	input_display.visible = toggle
 	commit_labl.visible = toggle
 	debug_label.visible = toggle
+	_toggle_debug_hitboxes()
+
+func _toggle_debug_hitboxes():
+	var toggle: bool = GameState.debug_toggle_collision_shapes
+	get_tree().set_debug_collisions_hint(toggle)
+	# This fixes some buggy behavior which causes the changes to not be visible unless the window is resized.
+	get_tree().root.emit_signal(&"visibility_changed")
 
 
 func _set_player():

--- a/util/globals/game_state.gd
+++ b/util/globals/game_state.gd
@@ -9,6 +9,7 @@ signal reload
 signal paused
 
 var debug_toggle: bool = false
+var debug_toggle_collision_shapes: bool = false
 
 var fullscreened: bool = false
 
@@ -36,6 +37,7 @@ func _ready():
 
 	buses[&"Music"].update_mute(LocalSettings.load_setting("Audio", "music_muted", false))
 	debug_toggle = LocalSettings.load_setting("Developer", "debug_toggle", false)
+	debug_toggle_collision_shapes = LocalSettings.load_setting("Developer", "debug_toggle_collision_shapes", false)
 
 
 #func _process(_delta: float) -> void:
@@ -61,6 +63,10 @@ func _unhandled_input(event):
 	if event.is_action_pressed(&"debug_toggle"):
 		debug_toggle = !debug_toggle
 		LocalSettings.change_setting("Developer", "debug_toggle", debug_toggle)
+	
+	if event.is_action_pressed(&"debug_toggle_collision_shapes"):
+		debug_toggle_collision_shapes = !debug_toggle_collision_shapes
+		LocalSettings.change_setting("Developer", "debug_toggle_collision_shapes", debug_toggle_collision_shapes)
 
 
 func _setting_changed(key: String, value: Variant):


### PR DESCRIPTION
Uses the F3 key to toggle visibility of collision shapes. Can be extended for paths and navigation areas if/when those are implemented.