### PR TITLE
Fix crash on new config

### DIFF
--- a/ui/buttons/ui_bind_button.gd
+++ b/ui/buttons/ui_bind_button.gd
@@ -170,7 +170,7 @@ func _return_to_idle():
 ## Checks if an event is parsable by using the defined classes in [member parsable_events].
 func _is_valid_event(event: InputEvent) -> bool:
 	for event_type: InputEvent in parsable_events:
-		if event.is_class(event_type.get_class()):
+		if event_type and event.is_class(event_type.get_class()):
 			return true
 
 	return false


### PR DESCRIPTION
The game would crash if there's no config file because of that mysterious extra null value, so just adding a check for a valid event_type seems to remedy that.